### PR TITLE
Lowercase org-mode src block

### DIFF
--- a/snippets/org-mode/src
+++ b/snippets/org-mode/src
@@ -2,6 +2,6 @@
 # name: src
 # key: <src
 # --
-#+BEGIN_SRC $1
+#+begin_src $1
   $0
-#+END_SRC
+#+end_src


### PR DESCRIPTION
So that its capitalization is consistent with all the other org-mode block snippets.